### PR TITLE
Attach an EIP to EC2 so that we can swap EC2 profiles with no disruption

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # Local .terraform directories
 **/.terraform/*
+.terraform.lock.hcl
 
 # .tfstate files
 *.tfstate

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,12 +1,12 @@
 output "ec2_instance_dns" {
-  value = aws_instance.openvpn.public_dns
+  value = aws_eip.openvpn_eip.public_dns
 }
 
 output "ec2_instance_ip" {
-  value = aws_instance.openvpn.public_ip
+  value = aws_eip.openvpn_eip.public_ip
 }
 
 output "connection_string" {
-  value = "'ssh -i ${var.ssh_private_key_file} ${var.ec2_username}@${aws_instance.openvpn.public_dns}'"
+  value = "'ssh -i ${var.ssh_private_key_file} ${var.ec2_username}@${aws_eip.openvpn_eip.public_dns}'"
 }
 


### PR DESCRIPTION
Before all, thanks for sharing such a nice project! Helped me a lot. 

So, here goes something that would make this project a bit more resilient on changes. I just attached an EIP along with the provisioned EC2 instance. In my case, I was basically swapping over instance profiles like t2.micro, t2.nano, t2.medium and measuring bandwidth. 

The problem was that for each update, a new IP address has been generated and I had to change de .ovpn accordingly. 

Having this elastic IP in front of the instance made my life easier! :)